### PR TITLE
Otel PR cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -280,6 +280,10 @@ dotnet_diagnostic.IDE0200.severity = none
 dotnet_diagnostic.IDE0240.severity = warning
 
 # Additional rules for template engine source code
+
+# Default severity for analyzer diagnostics with category 'StyleCop.CSharp.SpacingRules'
+dotnet_analyzer_diagnostic.category-StyleCop.CSharp.SpacingRules.severity = none
+
 [{src,test}/**{Microsoft.TemplateEngine.*,dotnet-new?*}/**.cs]
 # Default analyzed API surface = 'public' (public APIs)
 dotnet_code_quality.api_surface = public

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Activities.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Activities.cs
@@ -5,10 +5,9 @@ using System.Diagnostics;
 
 namespace Microsoft.DotNet.Cli.Utils;
 
-
 public static class Activities
 {
-    public static ActivitySource s_source = new("dotnet-cli", Product.Version);
+    public static ActivitySource Source { get; } = new("dotnet-cli", Product.Version);
 
     public const string DOTNET_CLI_TRACEPARENT = nameof(DOTNET_CLI_TRACEPARENT);
     public const string DOTNET_CLI_TRACESTATE = nameof(DOTNET_CLI_TRACESTATE);

--- a/src/Cli/Microsoft.DotNet.InternalAbstractions/FilePath.cs
+++ b/src/Cli/Microsoft.DotNet.InternalAbstractions/FilePath.cs
@@ -1,34 +1,33 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.EnvironmentAbstractions
+namespace Microsoft.Extensions.EnvironmentAbstractions;
+
+public readonly struct FilePath
 {
-    public struct FilePath
+    public string Value { get; }
+
+    /// <summary>
+    /// Create FilePath to represent an absolute file path. Note: It may not exist.
+    /// </summary>
+    /// <param name="value">If the value is not rooted. Path.GetFullPath will be called during the constructor.</param>
+    public FilePath(string value)
     {
-        public string Value { get; }
-
-        /// <summary>
-        /// Create FilePath to represent an absolute file path. Note it may not exist.
-        /// </summary>
-        /// <param name="value">If the value is not rooted. Path.GetFullPath will be called during the constructor.</param>
-        public FilePath(string value)
+        if (!Path.IsPathRooted(value))
         {
-            if (!Path.IsPathRooted(value))
-            {
-                value = Path.GetFullPath(value);
-            }
-
-            Value = value;
+            value = Path.GetFullPath(value);
         }
 
-        public override string ToString()
-        {
-            return Value;
-        }
+        Value = value;
+    }
 
-        public DirectoryPath GetDirectoryPath()
-        {
-            return new DirectoryPath(Path.GetDirectoryName(Value)!);
-        }
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public DirectoryPath GetDirectoryPath()
+    {
+        return new DirectoryPath(Path.GetDirectoryName(Value)!);
     }
 }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs
@@ -51,13 +51,13 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Arity = new ArgumentArity(0, 999)
         };
 
-        internal IReadOnlyList<Option> PassByOptions { get; } = new Option[]
-        {
+        internal IReadOnlyList<Option> PassByOptions { get; } =
+        [
             SharedOptions.ForceOption,
             SharedOptions.NameOption,
             SharedOptions.DryRunOption,
             SharedOptions.NoUpdateCheckOption
-        };
+        ];
 
         internal static Task<NewCommandStatus> ExecuteAsync(
             NewCommandArgs newCommandArgs,
@@ -74,7 +74,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             HostSpecificDataLoader hostSpecificDataLoader,
             CancellationToken cancellationToken)
         {
-            using var createTemplateGroupsActivity = Activities.s_source.StartActivity("create-template-groups");
+            using var createTemplateGroupsActivity = Activities.Source.StartActivity("create-template-groups");
             IReadOnlyList<ITemplateInfo> templates = await templatePackageManager.GetTemplatesAsync(cancellationToken).ConfigureAwait(false);
             return TemplateGroup.FromTemplateList(CliTemplateInfo.FromTemplateInfo(templates, hostSpecificDataLoader));
         }
@@ -85,7 +85,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 TemplatePackageManager templatePackageManager,
                 TemplateGroup templateGroup)
         {
-            using var getTemplateActivity = Activities.s_source.StartActivity("get-template-command");
+            using var getTemplateActivity = Activities.Source.StartActivity("get-template-command");
             //groups templates in the group by precedence
             foreach (IGrouping<int, CliTemplateInfo> templateGrouping in templateGroup.Templates.GroupBy(g => g.Precedence).OrderByDescending(g => g.Key))
             {
@@ -116,7 +116,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                     templateGroup,
                     candidates);
             }
-            return new HashSet<TemplateCommand>();
+            return [];
         }
 
         internal static void HandleNoMatchingTemplateGroup(InstantiateCommandArgs instantiateArgs, IEnumerable<TemplateGroup> templateGroups, IReporter reporter)
@@ -206,7 +206,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
                 return await templateListCoordinator.DisplayCommandDescriptionAsync(instantiateArgs, cancellationToken).ConfigureAwait(false);
             }
-            using var createActivity = Activities.s_source.StartActivity("instantiate-command");
+            using var createActivity = Activities.Source.StartActivity("instantiate-command");
             createActivity?.DisplayName = $"Invoke '{instantiateArgs.ShortName}'";
 
             IEnumerable<TemplateGroup> allTemplateGroups = await GetTemplateGroupsAsync(
@@ -277,7 +277,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             {
                 TemplateCommand templateCommandToRun = candidates.Single();
                 args.Command.Subcommands.Add(templateCommandToRun);
-                var templateParseActivity = Activities.s_source.StartActivity("reparse-for-template");
+                var templateParseActivity = Activities.Source.StartActivity("reparse-for-template");
                 ParseResult updatedParseResult = args.ParseResult.RootCommandResult.Command.Parse(
                     args.ParseResult.Tokens.Select(t => t.Value).ToArray(),
                     args.ParseResult.Configuration);

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
     internal class TemplateCommand : Command
     {
         private static readonly TimeSpan ConstraintEvaluationTimeout = TimeSpan.FromMilliseconds(1000);
-        private static readonly string[] _helpAliases = new[] { "-h", "/h", "--help", "-?", "/?" };
+        private static readonly string[] _helpAliases = ["-h", "/h", "--help", "-?", "/?"];
         private readonly TemplatePackageManager _templatePackageManager;
         private readonly IEngineEnvironmentSettings _environmentSettings;
         private readonly BaseCommand _instantiateCommand;
@@ -146,7 +146,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         internal async Task<NewCommandStatus> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
-            using var templateInvocationActivity = Activities.s_source.StartActivity("invoke-template");
+            using var templateInvocationActivity = Activities.Source.StartActivity("invoke-template");
             TemplateCommandArgs args = new(this, _instantiateCommand, parseResult);
             TemplateInvoker invoker = new(_environmentSettings, () => Console.ReadLine() ?? string.Empty);
             TemplatePackageCoordinator packageCoordinator = new(_environmentSettings, _templatePackageManager);
@@ -162,7 +162,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             if (!args.IsForceFlagSpecified)
             {
-                using var constraintResultsActivity = Activities.s_source.StartActivity("validate-constraints");
+                using var constraintResultsActivity = Activities.Source.StartActivity("validate-constraints");
                 var constraintResults = await constraintsEvaluation.ConfigureAwait(false);
                 if (constraintResults.Any())
                 {
@@ -177,7 +177,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Task<(string Id, string Version, string Provider)> builtInPackageCheck = packageCoordinator.ValidateBuiltInPackageAvailabilityAsync(args.Template, cancellationToken);
             Task<CheckUpdateResult?> checkForUpdateTask = packageCoordinator.CheckUpdateForTemplate(args, cancellationToken);
 
-            Task[] tasksToWait = new Task[] { instantiateTask, builtInPackageCheck, checkForUpdateTask };
+            Task[] tasksToWait = [instantiateTask, builtInPackageCheck, checkForUpdateTask];
 
             await Task.WhenAll(tasksToWait).ConfigureAwait(false);
             Reporter.Output.WriteLine();

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -37,7 +37,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         internal async Task<NewCommandStatus> InvokeTemplateAsync(TemplateCommandArgs templateArgs, CancellationToken cancellationToken)
         {
-            using var invokerActivity = Activities.s_source.StartActivity("invoker-invoking");
+            using var invokerActivity = Activities.Source.StartActivity("invoker-invoking");
             cancellationToken.ThrowIfCancellationRequested();
 
             CliTemplateInfo templateToRun = templateArgs.Template;
@@ -159,7 +159,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             try
             {
-                using var templateCreationActivity = Activities.s_source.StartActivity("actual-instantiate-template");
+                using var templateCreationActivity = Activities.Source.StartActivity("actual-instantiate-template");
                 instantiateResult = await _templateCreator.InstantiateAsync(
                     templateArgs.Template,
                     templateArgs.Name,
@@ -308,7 +308,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         private NewCommandStatus HandlePostActions(ITemplateCreationResult creationResult, TemplateCommandArgs args)
         {
-            using var postActionActivity = Activities.s_source.StartActivity("post-actions");
+            using var postActionActivity = Activities.Source.StartActivity("post-actions");
             PostActionExecutionStatus result = _postActionDispatcher.Process(creationResult, args.IsDryRun, args.AllowScripts ?? AllowRunScripts.Prompt);
 
             return result switch

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateListCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateListCoordinator.cs
@@ -24,13 +24,12 @@ namespace Microsoft.TemplateEngine.Cli
             IEngineEnvironmentSettings engineEnvironmentSettings,
             TemplatePackageManager templatePackageManager,
             IHostSpecificDataLoader hostSpecificDataLoader)
-
         {
             _engineEnvironmentSettings = engineEnvironmentSettings ?? throw new ArgumentNullException(nameof(engineEnvironmentSettings));
             _templatePackageManager = templatePackageManager ?? throw new ArgumentNullException(nameof(templatePackageManager));
             _hostSpecificDataLoader = hostSpecificDataLoader ?? throw new ArgumentNullException(nameof(hostSpecificDataLoader));
             _defaultLanguage = engineEnvironmentSettings.GetDefaultLanguage();
-            using var constraintManagerActivity = Activities.s_source.StartActivity("create-constraints");
+            using var constraintManagerActivity = Activities.Source.StartActivity("create-constraints");
             _constraintManager = new TemplateConstraintManager(_engineEnvironmentSettings);
         }
 
@@ -49,7 +48,6 @@ namespace Microsoft.TemplateEngine.Cli
             ListTemplateResolver resolver = new(_constraintManager, _templatePackageManager, _hostSpecificDataLoader);
             TemplateResolutionResult resolutionResult = await resolver.ResolveTemplatesAsync(args, _defaultLanguage, cancellationToken).ConfigureAwait(false);
 
-            //IReadOnlyDictionary<string, string?>? appliedParameterMatches = resolutionResult.GetAllMatchedParametersList();
             if (resolutionResult.TemplateGroupsWithMatchingTemplateInfoAndParameters.Any())
             {
                 Reporter.Output.WriteLine(LocalizableStrings.TemplatesFoundMatchingInputParameters, GetInputParametersString(args));
@@ -67,10 +65,10 @@ namespace Microsoft.TemplateEngine.Cli
             }
             else
             {
-                //if there is no criteria and filters it means that dotnet new list was run but there is no templates installed.
+                // If there is no criteria and filters, it means that dotnet new list was run but there are no templates installed.
                 if (args.ListNameCriteria == null && !args.AppliedFilters.Any())
                 {
-                    //No templates installed.
+                    // No templates installed.
                     Reporter.Output.WriteLine(LocalizableStrings.NoTemplatesFound);
                     Reporter.Output.WriteLine();
                     // To search for the templates on NuGet.org, run:
@@ -84,7 +82,7 @@ namespace Microsoft.TemplateEngine.Cli
                     return NewCommandStatus.Success;
                 }
 
-                // at least one criteria was specified.
+                // At least one criteria was specified.
                 // No templates found matching the following input parameter(s): {0}.
                 Reporter.Error.WriteLine(
                     string.Format(
@@ -196,33 +194,30 @@ namespace Microsoft.TemplateEngine.Cli
             return NewCommandStatus.Success;
         }
 
-        private static string GetInputParametersString(ListCommandArgs args/*, IReadOnlyDictionary<string, string?>? templateParameters = null*/)
+        private static string GetInputParametersString(ListCommandArgs args)
         {
             string separator = ", ";
             IEnumerable<string> appliedFilters = args.AppliedFilters
                     .Select(filter => $"{args.GetFilterToken(filter)}='{args.GetFilterValue(filter)}'");
-
-            //IEnumerable<string> appliedTemplateParameters = templateParameters?
-            //       .Select(param => string.IsNullOrWhiteSpace(param.Value) ? param.Key : $"{param.Key}='{param.Value}'") ?? Array.Empty<string>();
 
             StringBuilder inputParameters = new();
             string? mainCriteria = args.ListNameCriteria;
             if (!string.IsNullOrWhiteSpace(mainCriteria))
             {
                 inputParameters.Append($"'{mainCriteria}'");
-                if (appliedFilters.Any()/* || appliedTemplateParameters.Any()*/)
+                if (appliedFilters.Any())
                 {
                     inputParameters.Append(separator);
                 }
             }
-            if (appliedFilters/*.Concat(appliedTemplateParameters)*/.Any())
+            if (appliedFilters.Any())
             {
-                inputParameters.Append(string.Join(separator, appliedFilters/*.Concat(appliedTemplateParameters)*/));
+                inputParameters.Append(string.Join(separator, appliedFilters));
             }
             return inputParameters.ToString();
         }
 
-        private static string GetPartialMatchReason(TemplateResolutionResult templateResolutionResult, ListCommandArgs args/*, IReadOnlyDictionary<string, string?>? templateParameters = null*/)
+        private static string GetPartialMatchReason(TemplateResolutionResult templateResolutionResult, ListCommandArgs args)
         {
             string separator = ", ";
 
@@ -231,15 +226,10 @@ namespace Microsoft.TemplateEngine.Cli
                     .Where(filter => filter.MismatchCriteria(templateResolutionResult))
                     .Select(filter => $"{args.GetFilterToken(filter)}='{args.GetFilterValue(filter)}'");
 
-            //IEnumerable<string> appliedTemplateParameters = templateParameters?
-            //       .Where(parameter =>
-            //            templateResolutionResult.IsParameterMismatchReason(parameter.Key))
-            //       .Select(param => string.IsNullOrWhiteSpace(param.Value) ? param.Key : $"{param.Key}='{param.Value}'") ?? Array.Empty<string>();
-
             StringBuilder inputParameters = new();
-            if (appliedFilters/*.Concat(appliedTemplateParameters)*/.Any())
+            if (appliedFilters.Any())
             {
-                inputParameters.Append(string.Join(separator, appliedFilters/*.Concat(appliedTemplateParameters)*/));
+                inputParameters.Append(string.Join(separator, appliedFilters));
             }
             return inputParameters.ToString();
         }

--- a/src/Cli/dotnet/CliSchema.cs
+++ b/src/Cli/dotnet/CliSchema.cs
@@ -33,8 +33,20 @@ internal static class CliSchema
         TypeInfoResolver = new DefaultJsonTypeInfoResolver()
     };
 
-    public record ArgumentDetails(string? description, int order, bool hidden, string? helpName, string valueType, bool hasDefaultValue, object? defaultValue, ArityDetails arity);
-    public record ArityDetails(int minimum, int? maximum);
+    public record ArgumentDetails(
+        string? description,
+        int order,
+        bool hidden,
+        string? helpName,
+        string valueType,
+        bool hasDefaultValue,
+        object? defaultValue,
+        ArityDetails arity);
+
+    public record ArityDetails(
+        int minimum,
+        int? maximum);
+
     public record OptionDetails(
         string? description,
         bool hidden,
@@ -45,8 +57,8 @@ internal static class CliSchema
         object? defaultValue,
         ArityDetails arity,
         bool required,
-        bool recursive
-    );
+        bool recursive);
+
     public record CommandDetails(
         string? description,
         bool hidden,
@@ -54,6 +66,7 @@ internal static class CliSchema
         Dictionary<string, ArgumentDetails>? arguments,
         Dictionary<string, OptionDetails>? options,
         Dictionary<string, CommandDetails>? subcommands);
+
     public record RootCommandDetails(
         string name,
         string version,
@@ -64,7 +77,6 @@ internal static class CliSchema
         Dictionary<string, OptionDetails>? options,
         Dictionary<string, CommandDetails>? subcommands
     ) : CommandDetails(description, hidden, aliases, arguments, options, subcommands);
-
 
     public static void PrintCliSchema(CommandResult commandResult, TextWriter outputWriter, ITelemetry? telemetryClient)
     {

--- a/src/Cli/dotnet/CommandDirectoryContext.cs
+++ b/src/Cli/dotnet/CommandDirectoryContext.cs
@@ -35,7 +35,7 @@ internal static class CommandDirectoryContext
                 $"Calls to {nameof(CommandDirectoryContext)}.{nameof(PerformActionWithBasePath)} cannot be nested.");
         }
         _basePath = basePath;
-        Telemetry.Telemetry.CurrentSessionId = null;
+        Telemetry.Telemetry.s_currentSessionId = null;
         try
         {
             action();

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2522,4 +2522,7 @@ Proceed?</value>
     <value>Tool package download needs confirmation. Run in interactive mode or use the "--yes" command-line option to confirm.</value>
     <comment>{Locked="--yes"}</comment>
   </data>
+  <data name="ToolInstallPackageIdMissing" xml:space="preserve">
+    <value>A package ID was not specified for tool installation.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/Commands/Hidden/InternalReportInstallSuccess/InternalReportInstallSuccessCommand.cs
+++ b/src/Cli/dotnet/Commands/Hidden/InternalReportInstallSuccess/InternalReportInstallSuccessCommand.cs
@@ -39,18 +39,19 @@ public class InternalReportInstallSuccessCommand
 
     internal class ThreadBlockingTelemetry : ITelemetry
     {
-        private readonly Telemetry.Telemetry telemetry;
+        private readonly Telemetry.Telemetry _telemetry;
 
         internal ThreadBlockingTelemetry()
         {
             var sessionId = Environment.GetEnvironmentVariable(TelemetrySessionIdEnvironmentVariableName);
-            telemetry = new Telemetry.Telemetry(sessionId);
+            _telemetry = new Telemetry.Telemetry(sessionId);
         }
-        public bool Enabled => telemetry.Enabled;
+
+        public bool Enabled => _telemetry.Enabled;
 
         public void TrackEvent(string eventName, IDictionary<string, string?>? properties, IDictionary<string, double>? measurements)
         {
-            telemetry.ThreadBlockingTrackEvent(eventName, properties, measurements);
+            _telemetry.ThreadBlockingTrackEvent(eventName, properties, measurements);
         }
     }
 }

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
@@ -30,7 +30,7 @@ public class MSBuildForwardingApp : CommandBase
             }
             catch (Exception)
             {
-                // Exceptions during telemetry shouldn't cause anything else to fail
+                // Exceptions during _telemetry shouldn't cause anything else to fail
             }
         }
         return argsToForward;

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
@@ -18,7 +18,7 @@ public class MSBuildForwardingApp : CommandBase
 
     private static IEnumerable<string> ConcatTelemetryLogger(IEnumerable<string> argsToForward)
     {
-        if (Telemetry.Telemetry.CurrentSessionId != null)
+        if (Telemetry.Telemetry.s_currentSessionId != null)
         {
             try
             {
@@ -66,7 +66,7 @@ public class MSBuildForwardingApp : CommandBase
 
     private void InitializeRequiredEnvironmentVariables()
     {
-        EnvironmentVariable(TelemetrySessionIdEnvironmentVariableName, Telemetry.Telemetry.CurrentSessionId);
+        EnvironmentVariable(TelemetrySessionIdEnvironmentVariableName, Telemetry.Telemetry.s_currentSessionId);
     }
 
     /// <summary>

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingLogger.cs
@@ -26,7 +26,7 @@ public sealed class MSBuildForwardingLogger : IForwardingLogger
             eventSource4.IncludeEvaluationPropertiesAndItems();
         }
 
-        // Only forward telemetry events
+        // Only forward _telemetry events
         if (eventSource is IEventSource2 eventSource2)
         {
             eventSource2.TelemetryLogged += (sender, args) => BuildEventRedirector.ForwardEvent(args);

--- a/src/Cli/dotnet/Commands/New/BuiltInTemplatePackageProvider.cs
+++ b/src/Cli/dotnet/Commands/New/BuiltInTemplatePackageProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
@@ -19,14 +17,16 @@ internal sealed class BuiltInTemplatePackageProvider(BuiltInTemplatePackageProvi
 
     public ITemplatePackageProviderFactory Factory { get; } = factory;
 
-#pragma warning disable CS0067
     /// <summary>
     /// We don't trigger this event, we could complicate our life with FileSystemWatcher.
-    /// But since "dotnet new" is short lived process is not worth it, plus it would cause
-    /// some perf hit...
+    /// But since "dotnet new" is short lived process is not worth it, plus it would cause some perf hit...
+    /// To avoid warnings about being unused, implement empty add/remove accessors.
     /// </summary>
-    public event Action TemplatePackagesChanged;
-#pragma warning restore CS0067
+    public event Action? TemplatePackagesChanged
+    {
+        add { }
+        remove { }
+    }
 
     public Task<IReadOnlyList<ITemplatePackage>> GetAllTemplatePackagesAsync(CancellationToken cancellationToken)
     {
@@ -78,7 +78,7 @@ internal sealed class BuiltInTemplatePackageProvider(BuiltInTemplatePackageProvi
 
         foreach (string directory in Directory.EnumerateDirectories(fullPath, "*.*", SearchOption.TopDirectoryOnly))
         {
-            if (SemanticVersion.TryParse(Path.GetFileName(directory), out SemanticVersion versionInfo))
+            if (SemanticVersion.TryParse(Path.GetFileName(directory), out SemanticVersion? versionInfo) && versionInfo is not null)
             {
                 versionFileInfo.Add(directory, versionInfo);
             }
@@ -91,7 +91,7 @@ internal sealed class BuiltInTemplatePackageProvider(BuiltInTemplatePackageProvi
     {
         IDictionary<string, (string path, SemanticVersion version)> bestVersionsByBucket = new Dictionary<string, (string path, SemanticVersion version)>();
 
-        Version sdkVersion = typeof(NewCommandParser).Assembly.GetName().Version;
+        Version? sdkVersion = typeof(NewCommandParser).Assembly.GetName().Version;
         foreach (KeyValuePair<string, SemanticVersion> dirInfo in versionDirInfo)
         {
             var majorMinorDirVersion = new Version(dirInfo.Value.Major, dirInfo.Value.Minor);

--- a/src/Cli/dotnet/Commands/New/OptionalWorkloadProvider.cs
+++ b/src/Cli/dotnet/Commands/New/OptionalWorkloadProvider.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
-using Microsoft.DotNet.Cli.Commands.MSBuild;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 using Microsoft.TemplateEngine.Abstractions;
@@ -23,8 +20,8 @@ internal class OptionalWorkloadProvider : ITemplatePackageProvider
 
     public ITemplatePackageProviderFactory Factory { get; }
 
-    // To avoid warnings about unused, its implemented via add/remove
-    event Action ITemplatePackageProvider.TemplatePackagesChanged
+    // To avoid warnings about being unused, implement empty add/remove accessors.
+    event Action? ITemplatePackageProvider.TemplatePackagesChanged
     {
         add { }
         remove { }
@@ -35,12 +32,12 @@ internal class OptionalWorkloadProvider : ITemplatePackageProvider
         var list = new List<TemplatePackage>();
         var optionalWorkloadLocator = new TemplateLocator.TemplateLocator();
         var sdksDirectory = new DirectoryInfo(MSBuildForwardingAppWithoutLogging.GetMSBuildSDKsPath());
-        var sdkDirectory = sdksDirectory.Parent!;
-        var sdkVersion = sdkDirectory.Name;
-        var dotnetRootPath = sdkDirectory.Parent!.Parent!;
+        var sdkDirectory = sdksDirectory?.Parent;
+        var sdkVersion = sdkDirectory?.Name;
+        var dotnetRootPath = sdkDirectory?.Parent?.Parent;
         string userProfileDir = CliFolderPathCalculator.DotnetUserProfileFolderPath;
 
-        var packages = optionalWorkloadLocator.GetDotnetSdkTemplatePackages(sdkVersion, dotnetRootPath.FullName, userProfileDir);
+        var packages = optionalWorkloadLocator.GetDotnetSdkTemplatePackages(sdkVersion, dotnetRootPath?.FullName, userProfileDir);
         var fileSystem = _environmentSettings.Host.FileSystem;
         foreach (var packageInfo in packages)
         {

--- a/src/Cli/dotnet/Commands/NuGet/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/Commands/NuGet/NuGetCommandParser.cs
@@ -9,7 +9,7 @@ using NuGetWhyCommand = NuGet.CommandLine.XPlat.Commands.Why.WhyCommand;
 
 namespace Microsoft.DotNet.Cli.Commands.NuGet;
 
-// This parser is used for completion and telemetry.
+// This parser is used for completion and _telemetry.
 // See https://github.com/NuGet/NuGet.Client for the actual implementation.
 internal static class NuGetCommandParser
 {

--- a/src/Cli/dotnet/Commands/Test/TestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/TestCommand.cs
@@ -405,7 +405,7 @@ public class TerminalLoggerDetector
 
         string FindDefaultValue(IReadOnlyList<string> unmatchedTokens)
         {
-            // Find default configuration so it is part of telemetry even when default is not used.
+            // Find default configuration so it is part of _telemetry even when default is not used.
             // Default can be stored in /tlp:default=true|false|on|off|auto
             Switch terminalLoggerDefault = Find(unmatchedTokens, "tlp", "terminalloggerparameters");
             if (terminalLoggerDefault == null)

--- a/src/Cli/dotnet/Commands/Test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/TestingPlatformCommand.cs
@@ -129,7 +129,7 @@ internal partial class TestingPlatformCommand : Command, ICustomHelp
         var noProgress = parseResult.HasOption(TestingPlatformOptions.NoProgressOption);
         var noAnsi = parseResult.HasOption(TestingPlatformOptions.NoAnsiOption);
 
-        // TODO: Replace this with proper CI detection that we already have in telemetry. https://github.com/microsoft/testfx/issues/5533#issuecomment-2838893327
+        // TODO: Replace this with proper CI detection that we already have in _telemetry. https://github.com/microsoft/testfx/issues/5533#issuecomment-2838893327
         bool inCI = string.Equals(Environment.GetEnvironmentVariable("TF_BUILD"), "true", StringComparison.OrdinalIgnoreCase) || string.Equals(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), "true", StringComparison.OrdinalIgnoreCase);
 
         _output = new TerminalTestReporter(console, new TerminalTestReporterOptions()

--- a/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
@@ -7,19 +7,15 @@ using Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 using Microsoft.DotNet.Cli.Commands.Tool.Install;
 using Microsoft.DotNet.Cli.Commands.Tool.Restore;
 using Microsoft.DotNet.Cli.Commands.Tool.Run;
-using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolManifest;
 using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
-
 using Microsoft.Extensions.EnvironmentAbstractions;
-using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
-
 
 namespace Microsoft.DotNet.Cli.Commands.Tool.Execute;
 
@@ -89,11 +85,9 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
 
         (var bestVersion, var packageSource) = _toolPackageDownloader.GetNuGetVersion(packageLocation, packageId, _verbosity, versionRange, _restoreActionConfig);
 
-        IToolPackage toolPackage;
-
         //  TargetFramework is null, which means to use the current framework.  Global tools can override the target framework to use (or select assets for),
         //  but we don't support this for local or one-shot tools.
-        if (!_toolPackageDownloader.TryGetDownloadedTool(packageId, bestVersion, targetFramework: null, out toolPackage))
+        if (!_toolPackageDownloader.TryGetDownloadedTool(packageId, bestVersion, targetFramework: null, out IToolPackage toolPackage))
         {
             if (!UserAgreedToRunFromSource(packageId, bestVersion, packageSource))
             {
@@ -129,7 +123,7 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
 
         var commandSpec = ToolCommandSpecCreator.CreateToolCommandSpec(toolPackage.Command.Name.Value, toolPackage.Command.Executable.Value, toolPackage.Command.Runner, _allowRollForward, _forwardArguments);
         var command = CommandFactoryUsingResolver.Create(commandSpec);
-        using var _ = Activities.s_source.StartActivity("execute-inline-tool");
+        using var _ = Activities.Source.StartActivity("execute-inline-tool");
         var result = command.Execute();
         return result.ExitCode;
     }

--- a/src/Cli/dotnet/Commands/Tool/Install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ToolInstallGlobalOrToolPathCommand.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CommandLine;
-using System.Transactions;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
@@ -16,7 +13,6 @@ using Microsoft.DotNet.Cli.Utils.Extensions;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.ShellShim;
 using Microsoft.DotNet.Cli.Commands.Tool.Update;
-using Microsoft.DotNet.Cli.Commands.Tool.Common;
 using Microsoft.DotNet.Cli.Commands.Tool.Uninstall;
 using Microsoft.DotNet.Cli.Commands.Tool.List;
 
@@ -26,7 +22,7 @@ internal delegate IShellShimRepository CreateShellShimRepository(string appHostS
 
 internal delegate (IToolPackageStore, IToolPackageStoreQuery, IToolPackageDownloader) CreateToolPackageStoresAndDownloader(
     DirectoryPath? nonGlobalLocation = null,
-    IEnumerable<string> forwardRestoreArguments = null);
+    IEnumerable<string>? forwardRestoreArguments = null);
 
 internal class ToolInstallGlobalOrToolPathCommand : CommandBase
 {
@@ -35,36 +31,36 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
     private readonly CreateShellShimRepository _createShellShimRepository;
     private readonly CreateToolPackageStoresAndDownloaderAndUninstaller _createToolPackageStoreDownloaderUninstaller;
     private readonly ShellShimTemplateFinder _shellShimTemplateFinder;
-    private readonly IToolPackageStoreQuery _store;
+    private readonly IToolPackageStoreQuery? _store;
 
     private readonly PackageId? _packageId;
-    private readonly string _configFilePath;
-    private readonly string _framework;
-    private readonly string[] _source;
-    private readonly string[] _addSource;
+    private readonly string? _configFilePath;
+    private readonly string? _framework;
+    private readonly string[]? _source;
+    private readonly string[]? _addSource;
     private readonly bool _global;
     private readonly VerbosityOptions _verbosity;
-    private readonly string _toolPath;
-    private readonly string _architectureOption;
+    private readonly string? _toolPath;
+    private readonly string? _architectureOption;
     private readonly IEnumerable<string> _forwardRestoreArguments;
     private readonly bool _allowRollForward;
     private readonly bool _allowPackageDowngrade;
     private readonly bool _updateAll;
-    private readonly string _currentWorkingDirectory;
+    private readonly string? _currentWorkingDirectory;
     private readonly bool? _verifySignatures;
 
-    internal readonly RestoreActionConfig restoreActionConfig;
+    internal readonly RestoreActionConfig _restoreActionConfig;
 
     public ToolInstallGlobalOrToolPathCommand(
         ParseResult parseResult,
         PackageId? packageId = null,
-        CreateToolPackageStoresAndDownloaderAndUninstaller createToolPackageStoreDownloaderUninstaller = null,
-        CreateShellShimRepository createShellShimRepository = null,
-        IEnvironmentPathInstruction environmentPathInstruction = null,
-        IReporter reporter = null,
-        INuGetPackageDownloader nugetPackageDownloader = null,
-        IToolPackageStoreQuery store = null,
-        string currentWorkingDirectory = null,
+        CreateToolPackageStoresAndDownloaderAndUninstaller? createToolPackageStoreDownloaderUninstaller = null,
+        CreateShellShimRepository? createShellShimRepository = null,
+        IEnvironmentPathInstruction? environmentPathInstruction = null,
+        IReporter? reporter = null,
+        INuGetPackageDownloader? nugetPackageDownloader = null,
+        IToolPackageStoreQuery? store = null,
+        string? currentWorkingDirectory = null,
         bool? verifySignatures = null)
         : base(parseResult)
     {
@@ -92,11 +88,11 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
         var configOption = parseResult.GetValue(ToolInstallCommandParser.ConfigOption);
         var sourceOption = parseResult.GetValue(ToolInstallCommandParser.AddSourceOption);
         var packageSourceLocation = new PackageSourceLocation(string.IsNullOrEmpty(configOption) ? null : new FilePath(configOption), additionalSourceFeeds: sourceOption, basePath: _currentWorkingDirectory);
-        restoreActionConfig = new RestoreActionConfig(DisableParallel: parseResult.GetValue(ToolCommandRestorePassThroughOptions.DisableParallelOption),
+        _restoreActionConfig = new RestoreActionConfig(DisableParallel: parseResult.GetValue(ToolCommandRestorePassThroughOptions.DisableParallelOption),
             NoCache: parseResult.GetValue(ToolCommandRestorePassThroughOptions.NoCacheOption) || parseResult.GetValue(ToolCommandRestorePassThroughOptions.NoHttpCacheOption),
             IgnoreFailedSources: parseResult.GetValue(ToolCommandRestorePassThroughOptions.IgnoreFailedSourcesOption),
             Interactive: parseResult.GetValue(ToolCommandRestorePassThroughOptions.InteractiveRestoreOption));
-        nugetPackageDownloader ??= new NuGetPackageDownloader.NuGetPackageDownloader(tempDir, verboseLogger: new NullLogger(), restoreActionConfig: restoreActionConfig, verbosityOptions: _verbosity, verifySignatures: verifySignatures ?? true);
+        nugetPackageDownloader ??= new NuGetPackageDownloader.NuGetPackageDownloader(tempDir, verboseLogger: new NullLogger(), restoreActionConfig: _restoreActionConfig, verbosityOptions: _verbosity, verifySignatures: verifySignatures ?? true);
         _shellShimTemplateFinder = new ShellShimTemplateFinder(nugetPackageDownloader, tempDir, packageSourceLocation);
         _store = store;
 
@@ -125,10 +121,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
     {
         if (_updateAll)
         {
-            var toolListCommand = new ToolListGlobalOrToolPathCommand(
-                _parseResult
-                , toolPath => { return _store; }
-                );
+            var toolListCommand = new ToolListGlobalOrToolPathCommand(_parseResult, toolPath => { return _store; });
             var toolIds = toolListCommand.GetPackages(null, null);
             foreach (var toolId in toolIds)
             {
@@ -136,18 +129,25 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
             }
             return 0;
         }
-        else
+
+        if (_packageId is null)
         {
-            return ExecuteInstallCommand((PackageId)_packageId);
+            throw new GracefulException(CliCommandStrings.ToolInstallPackageIdMissing);
         }
+
+        return ExecuteInstallCommand((PackageId)_packageId);
     }
 
     private int ExecuteInstallCommand(PackageId packageId)
     {
-        using var _activity = Activities.s_source.StartActivity("install-tool");
+        using var _activity = Activities.Source.StartActivity("install-tool");
         _activity?.DisplayName = $"Install {packageId}";
         _activity?.SetTag("toolId", packageId);
-        ValidateArguments();
+
+        if (!string.IsNullOrEmpty(_configFilePath) && !File.Exists(_configFilePath))
+        {
+            throw new GracefulException(string.Format(CliCommandStrings.ToolInstallNuGetConfigurationFileDoesNotExist, Path.GetFullPath(_configFilePath)));
+        }
 
         DirectoryPath? toolPath = null;
         if (!string.IsNullOrEmpty(_toolPath))
@@ -165,9 +165,9 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
         var appHostSourceDirectory = ShellShimTemplateFinder.GetDefaultAppHostSourceDirectory();
         IShellShimRepository shellShimRepository = _createShellShimRepository(appHostSourceDirectory, toolPath);
 
-        IToolPackage oldPackageNullable = GetOldPackage(toolPackageStoreQuery, packageId);
+        IToolPackage? oldPackageNullable = GetOldPackage(toolPackageStoreQuery, packageId);
 
-        if (oldPackageNullable != null)
+        if (oldPackageNullable is not null)
         {
             NuGetVersion nugetVersion = GetBestMatchNugetVersion(packageId, versionRange, toolPackageDownloader);
             _activity?.DisplayName = $"Install {packageId}@{nugetVersion}";
@@ -182,7 +182,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
 
         TransactionalAction.Run(() =>
         {
-            if (oldPackageNullable != null)
+            if (oldPackageNullable is not null)
             {
                 RunWithHandlingUninstallError(() =>
                 {
@@ -193,9 +193,9 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
 
             RunWithHandlingInstallError(() =>
             {
-                var toolPackageDownloaderActivity = Activities.s_source.StartActivity("download-tool-package");
+                var toolPackageDownloaderActivity = Activities.Source.StartActivity("download-tool-package");
                 IToolPackage newInstalledPackage = toolPackageDownloader.InstallPackage(
-                new PackageLocation(nugetConfig: GetConfigFile(), sourceFeedOverrides: _source, additionalFeeds: _addSource),
+                    new PackageLocation(nugetConfig: GetConfigFile(), sourceFeedOverrides: _source, additionalFeeds: _addSource),
                     packageId: packageId,
                     versionRange: versionRange,
                     targetFramework: _framework,
@@ -203,13 +203,13 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
                     isGlobalTool: true,
                     isGlobalToolRollForward: _allowRollForward,
                     verifySignatures: _verifySignatures ?? true,
-                    restoreActionConfig: restoreActionConfig
+                    restoreActionConfig: _restoreActionConfig
                 );
                 toolPackageDownloaderActivity?.Dispose();
 
                 EnsureVersionIsHigher(oldPackageNullable, newInstalledPackage, _allowPackageDowngrade);
 
-                NuGetFramework framework;
+                NuGetFramework? framework;
                 if (string.IsNullOrEmpty(_framework) && newInstalledPackage.Frameworks.Count() > 0)
                 {
                     framework = newInstalledPackage.Frameworks
@@ -218,11 +218,9 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
                 }
                 else
                 {
-                    framework = string.IsNullOrEmpty(_framework) ?
-                        null :
-                        NuGetFramework.Parse(_framework);
+                    framework = string.IsNullOrEmpty(_framework) ? null : NuGetFramework.Parse(_framework);
                 }
-                var shimActivity = Activities.s_source.StartActivity("create-shell-shim");
+                var shimActivity = Activities.Source.StartActivity("create-shell-shim");
                 string appHostSourceDirectory = _shellShimTemplateFinder.ResolveAppHostSourceDirectoryAsync(_architectureOption, framework, RuntimeInformation.ProcessArchitecture).Result;
                 shellShimRepository.CreateShim(newInstalledPackage.Command, newInstalledPackage.PackagedShims);
                 shimActivity?.Dispose();
@@ -239,6 +237,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
                 PrintSuccessMessage(oldPackageNullable, newInstalledPackage);
             }, packageId);
         });
+
         return 0;
     }
 
@@ -249,37 +248,25 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
             packageId: packageId,
             versionRange: versionRange,
             verbosity: _verbosity,
-            restoreActionConfig: restoreActionConfig
+            restoreActionConfig: _restoreActionConfig
         ).version;
     }
 
-    private static bool ToolVersionAlreadyInstalled(IToolPackage oldPackageNullable, NuGetVersion nuGetVersion)
+    private static bool ToolVersionAlreadyInstalled(IToolPackage? oldPackageNullable, NuGetVersion nuGetVersion)
     {
         return oldPackageNullable != null && oldPackageNullable.Version == nuGetVersion;
     }
 
-    private static void EnsureVersionIsHigher(IToolPackage oldPackageNullable, IToolPackage newInstalledPackage, bool allowDowngrade)
+    private static void EnsureVersionIsHigher(IToolPackage? oldPackageNullable, IToolPackage newInstalledPackage, bool allowDowngrade)
     {
         if (oldPackageNullable != null && newInstalledPackage.Version < oldPackageNullable.Version && !allowDowngrade)
         {
             throw new GracefulException(
-                [
-                    string.Format(CliCommandStrings.UpdateToLowerVersion,
-                        newInstalledPackage.Version.ToNormalizedString(),
-                        oldPackageNullable.Version.ToNormalizedString())
-                ],
-                isUserError: false);
-        }
-    }
-
-    private void ValidateArguments()
-    {
-        if (!string.IsNullOrEmpty(_configFilePath) && !File.Exists(_configFilePath))
-        {
-            throw new GracefulException(
-                string.Format(
-                    CliCommandStrings.ToolInstallNuGetConfigurationFileDoesNotExist,
-                    Path.GetFullPath(_configFilePath)));
+            [
+                string.Format(CliCommandStrings.UpdateToLowerVersion,
+                    newInstalledPackage.Version.ToNormalizedString(),
+                    oldPackageNullable.Version.ToNormalizedString())
+            ], isUserError: false);
         }
     }
 
@@ -296,9 +283,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
             {
                 string.Format(CliCommandStrings.UpdateToolFailed, packageId)
             };
-            message.AddRange(
-                InstallToolCommandLowLevelErrorConverter.GetUserFacingMessages(ex, packageId));
-
+            message.AddRange(InstallToolCommandLowLevelErrorConverter.GetUserFacingMessages(ex, packageId));
 
             throw new GracefulException(
                 messages: message,
@@ -320,8 +305,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
             {
                 string.Format(CliCommandStrings.UpdateToolFailed, packageId)
             };
-            message.AddRange(
-                ToolUninstallCommandLowLevelErrorConverter.GetUserFacingMessages(ex, packageId));
+            message.AddRange(ToolUninstallCommandLowLevelErrorConverter.GetUserFacingMessages(ex, packageId));
 
             throw new GracefulException(
                 messages: message,
@@ -341,29 +325,25 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
         return configFile;
     }
 
-    private static IToolPackage GetOldPackage(IToolPackageStoreQuery toolPackageStoreQuery, PackageId packageId)
+    private static IToolPackage? GetOldPackage(IToolPackageStoreQuery toolPackageStoreQuery, PackageId packageId)
     {
-        IToolPackage oldPackageNullable;
+        IToolPackage? oldPackageNullable;
         try
         {
             oldPackageNullable = toolPackageStoreQuery.EnumeratePackageVersions(packageId).SingleOrDefault();
         }
         catch (InvalidOperationException)
         {
-            throw new GracefulException(
-                messages:
-                [
-                    string.Format(
-                        CliCommandStrings.ToolUpdateToolHasMultipleVersionsInstalled,
-                        packageId),
-                ],
-                isUserError: false);
+            throw new GracefulException(messages:
+            [
+                string.Format(CliCommandStrings.ToolUpdateToolHasMultipleVersionsInstalled, packageId)
+            ], isUserError: false);
         }
 
         return oldPackageNullable;
     }
 
-    private void PrintSuccessMessage(IToolPackage oldPackage, IToolPackage newInstalledPackage)
+    private void PrintSuccessMessage(IToolPackage? oldPackage, IToolPackage newInstalledPackage)
     {
         if (!_verbosity.IsQuiet())
         {
@@ -389,7 +369,6 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
             {
                 _reporter.WriteLine(
                     string.Format(
-
                         newInstalledPackage.Version.IsPrerelease ?
                         CliCommandStrings.UpdateSucceededPreVersionNoChange : CliCommandStrings.UpdateSucceededStableVersionNoChange,
                         newInstalledPackage.Id, newInstalledPackage.Version).Green());

--- a/src/Cli/dotnet/Commands/Tool/Run/ToolRunCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Run/ToolRunCommand.cs
@@ -1,27 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CommandLine;
 using Microsoft.DotNet.Cli.CommandFactory;
 using Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
-using Microsoft.DotNet.Cli.Commands.Tool.Install;
-using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolManifest;
-using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.DotNet.Cli.Commands.Tool.Run;
 
 internal class ToolRunCommand(
     ParseResult result,
-    LocalToolsCommandResolver localToolsCommandResolver = null,
-    ToolManifestFinder toolManifest = null) : CommandBase(result)
+    LocalToolsCommandResolver? localToolsCommandResolver = null,
+    ToolManifestFinder? toolManifest = null) : CommandBase(result)
 {
-    private readonly string _toolCommandName = result.GetValue(ToolRunCommandParser.CommandNameArgument);
-    private readonly IEnumerable<string> _forwardArgument = result.GetValue(ToolRunCommandParser.CommandArgument);
+    private readonly string? _toolCommandName = result.GetValue(ToolRunCommandParser.CommandNameArgument);
+    private readonly IEnumerable<string>? _forwardArgument = result.GetValue(ToolRunCommandParser.CommandArgument);
 
     private readonly LocalToolsCommandResolver _localToolsCommandResolver = localToolsCommandResolver ?? new LocalToolsCommandResolver(toolManifest);
     public bool _allowRollForward = result.GetValue(ToolRunCommandParser.RollForwardOption);
@@ -30,15 +24,15 @@ internal class ToolRunCommand(
     {
         return ExecuteCommand(_localToolsCommandResolver, _toolCommandName, _forwardArgument, _allowRollForward);
     }
-    public static int ExecuteCommand(LocalToolsCommandResolver commandResolver, string toolCommandName, IEnumerable<string> argumentsToForward, bool allowRollForward)
+
+    public static int ExecuteCommand(LocalToolsCommandResolver commandResolver, string? toolCommandName, IEnumerable<string>? argumentsToForward, bool allowRollForward)
     {
-        using var _ = Activities.s_source.StartActivity("execute-local-tool");
+        using var _ = Activities.Source.StartActivity("execute-local-tool");
         CommandSpec commandSpec = commandResolver.ResolveStrict(new CommandResolverArguments()
         {
             // since LocalToolsCommandResolver is a resolver, and all resolver input have dotnet-
             CommandName = $"dotnet-{toolCommandName}",
             CommandArguments = argumentsToForward,
-
         }, allowRollForward);
 
         if (commandSpec == null)

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -3075,6 +3075,11 @@ Nástroj {1} (verze {2}) byl úspěšně nainstalován.</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Nahradit všechny zdroje balíčků NuGet, které se mají použít při instalaci, těmito zdroji.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -3075,6 +3075,11 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert.</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Ersetzen alle NuGet-Paketquellen für die Nutzung während der Installation durch diese.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -3075,6 +3075,11 @@ La herramienta "{1}" (versión '{2}') se instaló correctamente.</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Reemplazar todos los orígenes de paquetes NuGet que se usarán durante la instalación por estos.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -3075,6 +3075,11 @@ L'outil '{1}' (version '{2}') a été installé correctement.</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Remplacer toutes les sources de package NuGet à utiliser pendant l’installation par celles-ci.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -3075,6 +3075,11 @@ Lo strumento '{1}' (versione '{2}') è stato installato.</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Sostituire tutte le origini del pacchetto NuGet da usare durante l'installazione con queste.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -3075,6 +3075,11 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">インストール中に使用するすべての NuGet パッケージ ソースをこれらに置き換えます。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -3075,6 +3075,11 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">설치 중에 사용할 모든 NuGet 패키지 원본을 이러한 패키지 원본으로 바꿉니다.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -3075,6 +3075,11 @@ Pomyślnie zainstalowano narzędzie „{1}” (wersja: „{2}”).</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Zastąp je wszystkimi źródłami pakietów NuGet, które mają być używane podczas instalacji.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -3075,6 +3075,11 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito.</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Substitua todas as fontes de pacote NuGet a serem usadas durante a instalação por estas.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -3075,6 +3075,11 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Замените ими все источники пакетов NuGet, которые будут использоваться при установке.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -3075,6 +3075,11 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Yükleme sırasında kullanılacak tüm NuGet paket kaynaklarını bu kaynaklarla değiştirin.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -3075,6 +3075,11 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">将安装期间要使用的所有 NuGet 包源替换为这些源。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -3075,6 +3075,11 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">以這些套件取代安裝期間使用的所有 NuGet 套件來源。</target>

--- a/src/Cli/dotnet/CommonOptionsFactory.cs
+++ b/src/Cli/dotnet/CommonOptionsFactory.cs
@@ -1,9 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
@@ -25,7 +24,7 @@ internal static class CommonOptionsFactory
         Arity = ArgumentArity.Zero
     };
 
-    internal class SetDiagnosticModeAction(Option<bool> diagnosticOption) : System.CommandLine.Invocation.SynchronousCommandLineAction
+    internal class SetDiagnosticModeAction(Option<bool> diagnosticOption) : SynchronousCommandLineAction
     {
         public override int Invoke(ParseResult parseResult)
         {
@@ -42,6 +41,7 @@ internal static class CommonOptionsFactory
                     Reporter.Reset();
                 }
             }
+
             return 0;
         }
     }

--- a/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Diagnostics;
@@ -17,21 +15,21 @@ namespace Microsoft.DotNet.Cli.Extensions;
 
 public static class ParseResultExtensions
 {
-    ///<summary>
+    /// <summary>
     /// Finds the command of the parse result and invokes help for that command.
     /// If no command is specified, invokes help for the application.
-    ///<summary>
-    ///<remarks>
+    /// <summary>
+    /// <remarks>
     /// This is accomplished by finding a set of tokens that should be valid and appending a help token
     /// to that list, then re-parsing the list of tokens. This is not ideal - either we should have a direct way
     /// of invoking help for a ParseResult, or we should eliminate this custom, ad-hoc help invocation by moving
     /// more situations that want to show help into Parsing Errors (which trigger help in the default System.CommandLine pipeline)
     /// or custom Invocation Middleware, so we can more easily create our version of a HelpResult type.
-    ///</remarks>
+    /// </remarks>
     public static void ShowHelp(this ParseResult parseResult)
     {
-        // take from the start of the list until we hit an option/--/unparsed token
-        // since commands can have arguments, we must take those as well in order to get accurate help
+        // Take from the start of the list until we hit an option/--/unparsed token.
+        // Since commands can have arguments, we must take those as well in order to get accurate help.
         var tokenList = parseResult.Tokens.TakeWhile(token => token.Type == TokenType.Argument || token.Type == TokenType.Command || token.Type == TokenType.Directive).Select(t => t.Value).ToList();
         tokenList.Add("-h");
         Instance.Parse(tokenList).Invoke();
@@ -57,14 +55,17 @@ public static class ParseResultExtensions
             }
         }
 
-        ///<summary>Splits a .NET format string by the format placeholders (the {N} parts) to get an array of the literal parts, to be used in message-checking</summary>
+        /// <summary>
+        /// Splits a .NET format string by the format placeholders (the {N} parts) to get an array of the literal parts, to be used in message-checking.
+        /// </summary>
         static string[] DistinctFormatStringParts(string formatString)
         {
             return Regex.Split(formatString, @"{[0-9]+}"); // match the literal '{', followed by any of 0-9 one or more times, followed by the literal '}'
         }
 
-
-        /// <summary>given a string and a series of parts, ensures that all parts are present in the string in sequential order</summary>
+        /// <summary>
+        /// Given a string and a series of parts, ensures that all parts are present in the string in sequential order.
+        /// </summary>
         static bool ErrorContainsAllParts(ReadOnlySpan<char> error, string[] parts)
         {
             foreach (var part in parts)
@@ -162,19 +163,12 @@ public static class ParseResultExtensions
         return false;
     }
 
-    private static string GetSymbolResultValue(ParseResult parseResult, SymbolResult symbolResult) => symbolResult switch
-    {
-        CommandResult commandResult => commandResult.Command.Name,
-        ArgumentResult argResult => argResult.Tokens.FirstOrDefault()?.Value ?? string.Empty,
-        _ => parseResult.GetResult(DotnetSubCommand)?.GetValueOrDefault<string>()
-    };
-
     public static bool BothArchAndOsOptionsSpecified(this ParseResult parseResult) =>
         (parseResult.HasOption(CommonOptions.ArchitectureOption) ||
         parseResult.HasOption(CommonOptions.LongFormArchitectureOption)) &&
         parseResult.HasOption(CommonOptions.OperatingSystemOption);
 
-    internal static string GetCommandLineRuntimeIdentifier(this ParseResult parseResult)
+    internal static string? GetCommandLineRuntimeIdentifier(this ParseResult parseResult)
     {
         return parseResult.HasOption(CommonOptions.RuntimeOptionName) ?
             parseResult.GetValue<string>(CommonOptions.RuntimeOptionName) :
@@ -189,7 +183,7 @@ public static class ParseResultExtensions
 
     public static bool UsingRunCommandShorthandProjectOption(this ParseResult parseResult)
     {
-        if (parseResult.HasOption(RunCommandParser.PropertyOption) && parseResult.GetValue(RunCommandParser.PropertyOption).Any())
+        if (parseResult.HasOption(RunCommandParser.PropertyOption) && (parseResult.GetValue(RunCommandParser.PropertyOption)?.Any() ?? false))
         {
             var projVals = parseResult.GetRunCommandShorthandProjectValues();
             if (projVals.Any())
@@ -225,7 +219,7 @@ public static class ParseResultExtensions
         var propertyValues = propertyOptions.SelectMany(o => o.Tokens.Select(t => t.Value)).ToArray();
         return propertyValues;
 
-        static Token GetOptionTokenOrDefault(SymbolResult symbolResult)
+        static Token? GetOptionTokenOrDefault(SymbolResult symbolResult)
         {
             if (symbolResult is not OptionResult optionResult)
             {
@@ -251,7 +245,7 @@ public static class ParseResultExtensions
     /// If you are inside a command handler or 'normal' System.CommandLine code then you don't need this - the parse error handling
     /// will have covered these cases.
     /// </summary>
-    public static T SafelyGetValueForOption<T>(this ParseResult parseResult, Option<T> optionToGet)
+    public static T? SafelyGetValueForOption<T>(this ParseResult parseResult, Option<T> optionToGet)
     {
         if (parseResult.GetResult(optionToGet) is OptionResult optionResult &&
             !parseResult.Errors.Any(e => e.SymbolResult == optionResult))

--- a/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
@@ -247,7 +247,7 @@ public static class ParseResultExtensions
 
     /// <summary>
     /// Only returns the value for this option if the option is present and there are no parse errors for that option.
-    /// This allows cross-cutting code like the telemetry filters to safely get the value without throwing on null-ref errors.
+    /// This allows cross-cutting code like the _telemetry filters to safely get the value without throwing on null-ref errors.
     /// If you are inside a command handler or 'normal' System.CommandLine code then you don't need this - the parse error handling
     /// will have covered these cases.
     /// </summary>

--- a/src/Cli/dotnet/Telemetry/ExternalTelemetryProperties.cs
+++ b/src/Cli/dotnet/Telemetry/ExternalTelemetryProperties.cs
@@ -10,7 +10,7 @@ using Microsoft.Win32;
 
 namespace Microsoft.DotNet.Cli.Telemetry;
 
-// Some properties we need for telemetry, that don't yet have suitable
+// Some properties we need for _telemetry, that don't yet have suitable
 // public API
 internal static class ExternalTelemetryProperties
 {
@@ -32,7 +32,7 @@ internal static class ExternalTelemetryProperties
         {
             return (string)Registry.GetValue(Key, ValueName, defaultValue: "");
         }
-        // Catch everything: this is for telemetry only.
+        // Catch everything: this is for _telemetry only.
         catch (Exception e)
         {
             Debug.Assert(e is ArgumentException | e is SecurityException | e is InvalidCastException);
@@ -64,7 +64,7 @@ internal static class ExternalTelemetryProperties
                 return productType.ToString("D", CultureInfo.InvariantCulture);
             }
         }
-        // Catch everything: this is for telemetry only
+        // Catch everything: this is for _telemetry only
         catch (Exception e)
         {
             Debug.Assert(false, $"Unexpected exception from GetProductInfo: ${e.GetType().Name}: ${e.Message}");
@@ -95,7 +95,7 @@ internal static class ExternalTelemetryProperties
         {
             return Marshal.PtrToStringUTF8(gnu_get_libc_release());
         }
-        // Catch everything: this is for telemetry only
+        // Catch everything: this is for _telemetry only
         catch (Exception e)
         {
             Debug.Assert(e is DllNotFoundException || e is EntryPointNotFoundException);
@@ -119,7 +119,7 @@ internal static class ExternalTelemetryProperties
         {
             return Marshal.PtrToStringUTF8(gnu_get_libc_version());
         }
-        // Catch everything: this is for telemetry only
+        // Catch everything: this is for _telemetry only
         catch (Exception e)
         {
             Debug.Assert(e is DllNotFoundException || e is EntryPointNotFoundException);

--- a/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
@@ -42,12 +42,8 @@ internal class TelemetryCommonProperties(
     private const string ProductType = "Product Type";
     private const string LibcRelease = "Libc Release";
     private const string LibcVersion = "Libc Version";
-
     private const string CI = "Continuous Integration";
-
     private const string TelemetryProfileEnvironmentVariable = "DOTNET_CLI_TELEMETRY_PROFILE";
-    private const string CannotFindMacAddress = "Unknown";
-
     private const string MachineIdCacheKey = "MachineId";
     private const string IsDockerContainerCacheKey = "IsDockerContainer";
 
@@ -67,8 +63,7 @@ internal class TelemetryCommonProperties(
             {CurrentPathHash, _hasher(_getCurrentDirectory())},
             {MachineIdOld, _userLevelCacheWriter.RunWithCache(MachineIdCacheKey, GetMachineId)},
             // we don't want to recalcuate a new id for every new SDK version. Reuse the same path across versions.
-            // If we change the format of the cache later.
-            // We need to rename the cache from v1 to v2
+            // If we change the format of the cache later, we need to rename the cache from v1 to v2.
             {MachineId,
                 _userLevelCacheWriter.RunWithCacheInFilePath(
                     Path.Combine(
@@ -86,15 +81,12 @@ internal class TelemetryCommonProperties(
 
     private string GetMachineId()
     {
-        var macAddress = _getMACAddress();
-        if (macAddress != null)
+        if (_getMACAddress() is { } macAddress)
         {
             return _hasher(macAddress);
         }
-        else
-        {
-            return Guid.NewGuid().ToString();
-        }
+
+        return Guid.NewGuid().ToString();
     }
 
     /// <summary>
@@ -131,8 +123,5 @@ internal class TelemetryCommonProperties(
     ///     Windows.7        Microsoft Windows 6.1.7601 S
     ///     Windows.81       Microsoft Windows 6.3.9600
     /// </summary>
-    private static string GetKernelVersion()
-    {
-        return RuntimeInformation.OSDescription;
-    }
+    private static string GetKernelVersion() => RuntimeInformation.OSDescription;
 }

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -71,7 +71,7 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
         string folderToDeleteOnFailure = null;
         return TransactionalAction.Run<NuGetVersion>(() =>
         {
-            var _downloadActivity = Activities.s_source.StartActivity("download-tool");
+            var _downloadActivity = Activities.Source.StartActivity("download-tool");
             _downloadActivity?.DisplayName = $"Downloading tool {packageId}@{packageVersion}";
             var packagePath = nugetPackageDownloader.DownloadPackageAsync(packageId, packageVersion, packageSourceLocation,
                         includeUnlisted: includeUnlisted, downloadFolder: new DirectoryPath(packagesRootPath)).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -94,7 +94,7 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
             }
 
             // Extract the package
-            var _extractActivity = Activities.s_source.StartActivity("extract-tool");
+            var _extractActivity = Activities.Source.StartActivity("extract-tool");
             var nupkgDir = versionFolderPathResolver.GetInstallPath(packageId.ToString(), version);
             nugetPackageDownloader.ExtractPackageAsync(packagePath, new DirectoryPath(nupkgDir)).ConfigureAwait(false).GetAwaiter().GetResult();
             _extractActivity?.Stop();

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloaderBase.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloaderBase.cs
@@ -191,7 +191,7 @@ internal abstract class ToolPackageDownloaderBase : IToolPackageDownloader
                 //  Create parent directory in global tool store, for example dotnet\tools\.store\powershell
                 _fileSystem.Directory.CreateDirectory(toolStoreTargetDirectory.GetParentPath().Value);
 
-                var _moveContentActivity = Activities.s_source.StartActivity("move-global-tool-content");
+                var _moveContentActivity = Activities.Source.StartActivity("move-global-tool-content");
                 //  Move tool files from stage to final location
                 FileAccessRetrier.RetryOnMoveAccessFailure(() => _fileSystem.Directory.Move(_globalToolStageDir.Value, toolStoreTargetDirectory.Value));
                 _moveContentActivity?.Dispose();
@@ -355,7 +355,7 @@ internal abstract class ToolPackageDownloaderBase : IToolPackageDownloader
         ToolPackageInstance toolPackageInstance
         )
     {
-        using var _updateRuntimeConfigActivity = Activities.s_source.StartActivity("update-runtimeconfig");
+        using var _updateRuntimeConfigActivity = Activities.Source.StartActivity("update-runtimeconfig");
         var runtimeConfigFilePath = Path.ChangeExtension(toolPackageInstance.Command.Executable.Value, ".runtimeconfig.json");
 
         // Update the runtimeconfig.json file

--- a/src/Microsoft.DotNet.TemplateLocator/TemplateLocator.cs
+++ b/src/Microsoft.DotNet.TemplateLocator/TemplateLocator.cs
@@ -36,8 +36,8 @@ namespace Microsoft.DotNet.TemplateLocator
         }
 
         public IReadOnlyCollection<IOptionalSdkTemplatePackageInfo> GetDotnetSdkTemplatePackages(
-            string sdkVersion,
-            string dotnetRootPath,
+            string? sdkVersion,
+            string? dotnetRootPath,
             string? userProfileDir)
         {
             if (string.IsNullOrWhiteSpace(sdkVersion))
@@ -47,8 +47,7 @@ namespace Microsoft.DotNet.TemplateLocator
 
             if (string.IsNullOrWhiteSpace(dotnetRootPath))
             {
-                throw new ArgumentException($"'{nameof(dotnetRootPath)}' cannot be null or whitespace",
-                    nameof(dotnetRootPath));
+                throw new ArgumentException($"'{nameof(dotnetRootPath)}' cannot be null or whitespace", nameof(dotnetRootPath));
             }
 
             //  Will the current directory correspond to the folder we are creating a project in?  If we need

--- a/test/dotnet.Tests/CommandTests/Tool/Install/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Tool/Install/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         {
             var parseResult = Parser.Instance.Parse($"dotnet tool install -g {PackageId} --ignore-failed-sources");
             var toolInstallCommand = new ToolInstallGlobalOrToolPathCommand(parseResult);
-            toolInstallCommand.restoreActionConfig.IgnoreFailedSources.Should().BeTrue();
+            toolInstallCommand._restoreActionConfig.IgnoreFailedSources.Should().BeTrue();
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/Tool/Update/ToolUpdateGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Tool/Update/ToolUpdateGlobalOrToolPathCommandTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         {
             var parseResult = Parser.Instance.Parse($"dotnet tool update -g {_packageId} --ignore-failed-sources");
             var toolUpdateCommand = new ToolUpdateGlobalOrToolPathCommand(parseResult);
-            toolUpdateCommand._toolInstallGlobalOrToolPathCommand.restoreActionConfig.IgnoreFailedSources.Should().BeTrue();
+            toolUpdateCommand._toolInstallGlobalOrToolPathCommand._restoreActionConfig.IgnoreFailedSources.Should().BeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

I went through the files that were modified and:
- Removed `#nullable disable` if it was still there
- Fixed some variable names
- Fixed public fields to be public properties
- Minor formatting/whitespace adjustments
- Removed some really old commented code
- Removed some unused methods and fields
- Cleaned up usings
- Added explicit accessors or readonly qualifiers to fields/properties/methods
- Adjusted some comments
- Random other minor adjustments

I did not adjust anything in `ToolPackageDownloader.cs` and `ToolPackageDownloaderBase.cs` since those will be adjusted when the [`any` RID PR](https://github.com/dotnet/sdk/pull/49505) is merged.